### PR TITLE
Fixed how we push timelock blocks parameter to the timelock script.

### DIFF
--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -90,7 +90,7 @@ impl ProtocolScript {
 pub fn timelock(blocks: u16, timelock_key: &PublicKey) -> ProtocolScript {
     let script = script!(
         // If blocks have passed since this transaction has been confirmed, the timelocked public key can spend the funds
-        { blocks.to_le_bytes().to_vec() }
+        { blocks as u32 }
         OP_CSV
         OP_DROP
         { XOnlyPublicKey::from(*timelock_key).serialize().to_vec() }


### PR DESCRIPTION
Timelock blocks are typed as u16 and tree++ doesn't have support to push u16 values due to u16 not implementing the trait pushable, producing unexpected errors when executing scripts with values of this type. Casting to u32 solves the issue, since u32 implements trait pushable (as u8 does).