### PR TITLE
Avoid adding multiple transactions using the same transaction name to TransactionGraph

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,6 +43,9 @@ pub enum GraphError {
 
     #[error("Transaction with txid {0} not found in graph")]
     TransactionNotFound(String),
+
+    #[error("Transaction with name {0} already exists in graph")]
+    TransactionAlreadyExists(String)
 }
 
 #[derive(Error, Debug)]

--- a/src/graph/graph.rs
+++ b/src/graph/graph.rs
@@ -72,6 +72,10 @@ impl TransactionGraph {
     }
 
     pub fn add_transaction(&mut self, name: &str, transaction: Transaction) -> Result<(), GraphError> {
+        if self.node_indexes.contains_key(name) {
+            return Err(GraphError::TransactionAlreadyExists(name.to_string()));
+        }
+        
         let node = Node::new(name, transaction);
         let node_index = self.graph.add_node(node.clone());
 


### PR DESCRIPTION
The check to avoid adding multiple transactions with the same name to a TransactionGraph happens in builder.rs, however, when using a TransactionGraph directly it is still possible to add multiple transactions using the same transaction name. This PR adds the check for an exist transaction with the specified name to the add_transaction method in TransactionGraph. If a transaction with the specified name already exists, the method returns a TransactionAlreadyExists Error.