### PR TITLE
Generate sighash and signature for the key spend path of taproot output

### DIFF
--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -478,7 +478,7 @@ impl ProtocolBuilder {
     }
 
     pub fn visualize(&self) -> Result<String, ProtocolBuilderError> {
-        Ok(self.protocol.visualize()?)
+        self.protocol.visualize()
     }
 
     fn save_protocol(&self) -> Result<(), ProtocolBuilderError> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -173,6 +173,9 @@ pub enum ProtocolBuilderError {
 
     #[error("Failed to push data in op_return script")]
     OpReturnDataError(#[from] PushBytesError),
+
+    #[error("Failed to generate signature for key spend path for taproot output with taptree")]
+    KeySpendSignatureGenerationFailed,
 }
 
 #[derive(Error, Debug)]

--- a/src/tests/builder_outputs_test.rs
+++ b/src/tests/builder_outputs_test.rs
@@ -179,7 +179,7 @@ mod tests {
             .build_and_sign(&key_manager)?;
 
         let signature = protocol
-            .input_taproot_signature("keypath_spend", 0, 0)
+            .input_taproot_script_spend_signature("keypath_spend", 0, 0)
             .unwrap();
         let mut spending_args = SpendingArgs::new_args();
         spending_args.push_taproot_signature(signature);


### PR DESCRIPTION
Enable the generation of the sighash and signature for the key spend path of a taproot output with a taptree.