### PR TITLE
If taptree has a single leaf it should be the root

### DIFF
--- a/src/builder/protocol.rs
+++ b/src/builder/protocol.rs
@@ -21,7 +21,7 @@ use crate::{
     errors::ProtocolBuilderError,
     graph::{
         graph::{MessageId, TransactionGraph},
-        input::{self, InputSignatures, InputSpendingInfo, SighashType, Signature},
+        input::{InputSignatures, InputSpendingInfo, SighashType, Signature},
         output::OutputSpendingType,
     },
     scripts::{self, ProtocolScript},

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -1,7 +1,7 @@
-use std::{cmp, collections::HashMap};
+use std::{collections::HashMap};
 
 use bitcoin::{
-    key::{Secp256k1, UntweakedPublicKey}, opcodes::all::{OP_CHECKSIGVERIFY, OP_SHA256}, secp256k1::All, taproot::{TaprootBuilder, TaprootSpendInfo}, PublicKey, ScriptBuf, XOnlyPublicKey
+    hex::{Case, DisplayHex}, key::{Secp256k1, UntweakedPublicKey}, secp256k1::All, taproot::{TaprootBuilder, TaprootSpendInfo}, PublicKey, ScriptBuf, XOnlyPublicKey
 };
 
 use bitcoin_scriptexec::treepp::*;
@@ -456,11 +456,13 @@ pub fn build_taproot_spend_info(
     taproot_spending_scripts: &[ProtocolScript],
 ) -> Result<TaprootSpendInfo, ScriptError> {
     let scripts_count = taproot_spending_scripts.len();
-
+    let mut depth = 0;
     // To build a taproot tree, we need to calculate the depth of the tree.
-    // If the list of scripts only contains 1 element, the depth is 1, otherwise we compute the depth
+    // If the list of scripts only contains 1 element, the depth is 0, otherwise we compute the depth
     // as the log2 of the number of scripts rounded up to the nearest integer.
-    let depth = cmp::max(1, (scripts_count as f32).log2().ceil() as u8);
+    if scripts_count > 1 {
+        depth = (scripts_count as f32).log2().ceil() as u8;
+    }
 
     let mut tr_builder = TaprootBuilder::new();
     for script in taproot_spending_scripts.iter() {
@@ -468,7 +470,7 @@ pub fn build_taproot_spend_info(
     }
 
     // If the number of spend conditions is odd, add the last one again
-    if scripts_count % 2 != 0 {
+    if  scripts_count > 1 && scripts_count % 2 != 0 {
         tr_builder = tr_builder.add_leaf(
             depth,
             taproot_spending_scripts[scripts_count - 1]


### PR DESCRIPTION
Also fix warnings for unused deps.

If there is a single leaf it should be the root as described in https://learnmeabitcoin.com/technical/upgrades/taproot/#construction
```
If you only have one leaf in your script tree, the merkle root will be that leaf hash.
If you do not use a script tree, your merkle will be empty (zero bytes).
```

Adding again the last element if the amount of elements is odd is not mandatory. It was added only to make the tree fit into the log2 depth.

See this counter example at rust-bitcoin that has 5 leafs https://github.com/rust-bitcoin/rust-bitcoin/blob/f7006e3d15c6d52a2c3d172807679c432022757e/bitcoin/src/taproot/mod.rs#L1872

```rust
let builder = TaprootBuilder::new();
        // Create a tree as shown below
        // For example, imagine this tree:
        // A, B , C are at depth 2 and D,E are at 3
        //                                       ....
        //                                     /      \
        //                                    /\      /\
        //                                   /  \    /  \
        //                                  A    B  C  / \
        //                                            D   E
        let a = ScriptBuf::from_hex("51").unwrap();
        let b = ScriptBuf::from_hex("52").unwrap();
        let c = ScriptBuf::from_hex("53").unwrap();
        let d = ScriptBuf::from_hex("54").unwrap();
        let e = ScriptBuf::from_hex("55").unwrap();
        let builder = builder.add_leaf(2, a.clone()).unwrap();
        let builder = builder.add_leaf(2, b.clone()).unwrap();
        let builder = builder.add_leaf(2, c.clone()).unwrap();
        let builder = builder.add_leaf(3, d.clone()).unwrap();

        // Trying to finalize an incomplete tree returns the Err(builder)
        let builder = builder.finalize(&secp, internal_key).unwrap_err();
        let builder = builder.add_leaf(3, e.clone()).unwrap();
```