### PR TITLE
Added LeafSpec to select the taproot leaf to spend by index or by leaf code. Fixed hash message and signature generation.

### DIFF
--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -48,13 +48,8 @@ impl ProtocolBuilder {
     ) -> Result<&Self, ProtocolBuilderError> {
         check_empty_scripts(leaves)?;
 
-        let output_type = OutputType::tr_script(
-            value,
-            internal_key,
-            leaves,
-            with_key_path,
-            prevouts,
-        )?;
+        let output_type =
+            OutputType::tr_script(value, internal_key, leaves, with_key_path, prevouts)?;
         protocol.add_transaction_output(transaction_name, output_type)?;
         Ok(self)
     }
@@ -445,13 +440,8 @@ impl ProtocolBuilder {
             to_round = format!("{0}_{1}", to, round);
 
             // Connection between the from and to transactions using the leaves_from.
-            let output_type = OutputType::tr_script(
-                value,
-                internal_key,
-                leaves_from,
-                with_key_path,
-                vec![],
-            )?;
+            let output_type =
+                OutputType::tr_script(value, internal_key, leaves_from, with_key_path, vec![])?;
             protocol.add_connection(
                 connection_name,
                 &from_round,
@@ -465,13 +455,8 @@ impl ProtocolBuilder {
             to_round = format!("{0}_{1}", to, round);
 
             // Reverse connection between the to and from transactions using the leaves_to.
-            let output_type = OutputType::tr_script(
-                value,
-                internal_key,
-                leaves_to,
-                with_key_path,
-                vec![],
-            )?;
+            let output_type =
+                OutputType::tr_script(value, internal_key, leaves_to, with_key_path, vec![])?;
             protocol.add_connection(
                 connection_name,
                 &to_round,
@@ -487,13 +472,8 @@ impl ProtocolBuilder {
         to_round = format!("{0}_{1}", to, rounds - 1);
 
         // Last direct connection using leaves_from.
-        let output_type = OutputType::tr_script(
-            value,
-            internal_key,
-            leaves_from,
-            with_key_path,
-            vec![],
-        )?;
+        let output_type =
+            OutputType::tr_script(value, internal_key, leaves_from, with_key_path, vec![])?;
         protocol.add_connection(
             connection_name,
             &from_round,

--- a/src/builder/check_params.rs
+++ b/src/builder/check_params.rs
@@ -1,8 +1,6 @@
 use crate::{errors::ProtocolBuilderError, scripts::ProtocolScript};
 
-pub(crate) fn check_empty_scripts(
-    scripts: &[ProtocolScript],
-) -> Result<(), ProtocolBuilderError> {
+pub(crate) fn check_empty_scripts(scripts: &[ProtocolScript]) -> Result<(), ProtocolBuilderError> {
     if scripts.is_empty() {
         return Err(ProtocolBuilderError::EmptyScripts);
     }

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -529,16 +529,12 @@ pub fn build_taproot_spend_info(
     let nodes_at_min_depth = total_slots - scripts_count;
     // Add leaves at minimum depth
     for i in 0..nodes_at_min_depth {
-        tr_builder =
-            tr_builder.add_leaf(min_depth, leaves[i].get_script().clone())?;
+        tr_builder = tr_builder.add_leaf(min_depth, leaves[i].get_script().clone())?;
     }
 
     // Add remaining leaves at minimum depth + 1
     for i in nodes_at_min_depth..scripts_count {
-        tr_builder = tr_builder.add_leaf(
-            min_depth + 1,
-            leaves[i].get_script().clone(),
-        )?;
+        tr_builder = tr_builder.add_leaf(min_depth + 1, leaves[i].get_script().clone())?;
     }
 
     tr_builder

--- a/src/tests/weight_computing_test.rs
+++ b/src/tests/weight_computing_test.rs
@@ -8,7 +8,10 @@ mod tests {
         helpers::weight_computing::{get_transaction_hex, get_transaction_vsize},
         scripts::ProtocolScript,
         tests::utils::{new_key_manager, TemporaryDir},
-        types::{input::{InputArgs, SighashType}, output::OutputType},
+        types::{
+            input::{InputArgs, LeafSpec, SighashType},
+            output::OutputType,
+        },
     };
 
     #[test]
@@ -104,12 +107,12 @@ mod tests {
         protocol.build_and_sign(&key_manager)?;
 
         let challenge_args = &[
-            InputArgs::new_taproot_script_args(0),
-            InputArgs::new_taproot_script_args(1),
+            InputArgs::new_taproot_script_args(LeafSpec::Index(0)),
+            InputArgs::new_taproot_script_args(LeafSpec::Index(1)),
         ];
         let response_args = &[
-            InputArgs::new_taproot_script_args(0),
-            InputArgs::new_taproot_script_args(1),
+            InputArgs::new_taproot_script_args(LeafSpec::Index(0)),
+            InputArgs::new_taproot_script_args(LeafSpec::Index(1)),
         ];
 
         let start = protocol.transaction_to_send("start", &[InputArgs::new_segwit_args()])?;


### PR DESCRIPTION
- Added the option to select the leaf to spend in a taproot transaction by specifying its index or its code
- Return self in add_transaction_output(), add_transaction_input(), add_transaction() 
- Fixed generation of hashed_messages for each transaction input, empty hashed messages must be pushed as None, instead of Some(vec![]).
- When skipping key path hash message and signature generation now a None is pushed to the hashed_messages array and the signatures array respectively. 
- Added checks for these changes. Fixed clippy warnings and code format