### PR TITLE
Make arrows start and end in boxes edges

### DIFF
--- a/src/graph/graph.rs
+++ b/src/graph/graph.rs
@@ -513,8 +513,12 @@ impl TransactionGraph {
                 //result.push_str(&format!( "{}:o{} -> {}:i{} [label={}]\n", from.name, connection.output_index, to.name, connection.input_index, connection.name,));
                 //Detailed from-to:in
                 result.push_str(&format!(
-                    "{} -> {}:i{} [label={}]\n",
-                    from.name, to.name, connection.input_index, connection.name,
+                    "{}:o{}:e -> {}:i{}:w [label={}]\n",
+                    from.name,
+                    connection.output_index,
+                    to.name,
+                    connection.input_index,
+                    connection.name,
                 ));
             }
         }


### PR DESCRIPTION
Getting something like this: 
<img width="7179" height="4235" alt="image" src="https://github.com/user-attachments/assets/9ec40d58-f4c2-4a57-9f1e-4c17f2a81d61" />
Instead of something like this:
<img width="1275" height="711" alt="image" src="https://github.com/user-attachments/assets/e305d3a1-930e-46fc-9e46-516bb4acc0ae" />
