### PR TITLE
Fix warning deprecated bitcoin::key::TweakedPublicKey::to_inner

### DIFF
--- a/src/builder/protocol.rs
+++ b/src/builder/protocol.rs
@@ -772,7 +772,7 @@ impl Protocol {
 
         if !control_block.verify_taproot_commitment(
             &secp,
-            spend_info.output_key().to_inner(),
+            spend_info.output_key().to_x_only_public_key(),
             &leaf,
         ) {
             return Err(ProtocolBuilderError::InvalidLeaf(input_index));


### PR DESCRIPTION
warning: use of deprecated method `bitcoin::key::TweakedPublicKey::to_inner`: use to_x_only_public_key() instead