### PR TITLE
fix: example calling deprecated fun

### DIFF
--- a/examples/protocol_example.rs
+++ b/examples/protocol_example.rs
@@ -34,7 +34,7 @@ fn protocol_example(key_manager: Rc<KeyManager>) -> Result<Protocol> {
     )?;
 
     // Winternitz key for the one-time authentication branch.
-    let winternitz_key = key_manager.derive_winternitz(32, WinternitzType::SHA256, 0)?;
+    let winternitz_key = key_manager.next_winternitz(32, WinternitzType::SHA256)?;
 
     // Taproot leaves showcasing each sign mode using the helper scripts.
     let skip_leaf = scripts::timelock(


### PR DESCRIPTION
In a past refactor I checked for compilation errors running `cargo bar` in the client (inside the workspace context) even if that compiles all the client deps (including protocol builder) it does not execute a `cargo bar` for each dep, so this example was unnoticeable broken